### PR TITLE
Add support for parentLocales

### DIFF
--- a/lib/cldr/download.rb
+++ b/lib/cldr/download.rb
@@ -5,7 +5,7 @@ require 'zip'
 module Cldr
   class << self
     def download(source = nil, target = nil)
-      source ||= 'http://unicode.org/Public/cldr/24/core.zip'
+      source ||= 'http://unicode.org/Public/cldr/26/core.zip'
       target ||= File.expand_path('./vendor/cldr')
 
       URI.parse(source).open do |tempfile|

--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -150,7 +150,7 @@ module Cldr
       end
 
       def component_should_merge_root?(component)
-        component != "Rbnf"
+        !%w(Rbnf Fields).include?(component)
       end
     end
   end

--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -1,5 +1,5 @@
 require 'i18n'
-require 'i18n/locale/fallbacks'
+require 'i18n/locale/tag'
 require 'core_ext/string/camelize'
 require 'core_ext/string/underscore'
 require 'core_ext/hash/deep_stringify_keys'
@@ -119,11 +119,25 @@ module Cldr
       end
 
       def locales(locale, component, options)
-        locale = locale.to_s.gsub('_', '-').to_sym
+        to_i18n = lambda {|l| l.to_s.gsub('_', '-').to_sym }
+        from_i18n = lambda {|l| l.to_s.gsub('-', '_') }
+        locale = to_i18n[locale]
 
         locales = if options[:merge]
-          # passing locale itself into constructor as a default fallback to avoid falling back to :en locale
-          I18n::Locale::Fallbacks.new([locale])[locale]
+          defined_parents = Cldr::Export::Data::ParentLocales.new
+
+          ancestory = [locale]
+          loop do
+            if defined_parents[from_i18n[ancestory.last]]
+              ancestory << to_i18n[defined_parents[from_i18n[ancestory.last]]]
+            elsif I18n::Locale::Tag.tag(ancestory.last).self_and_parents.count > 1
+              ancestory << I18n::Locale::Tag.tag(ancestory.last).self_and_parents.last.to_sym
+            else
+              break
+            end
+          end
+
+          ancestory
         else
           [locale]
         end

--- a/lib/cldr/export/data.rb
+++ b/lib/cldr/export/data.rb
@@ -18,6 +18,7 @@ module Cldr
       autoload :Metazones,                 'cldr/export/data/metazones'
       autoload :NumberingSystems,          'cldr/export/data/numbering_systems'
       autoload :Numbers,                   'cldr/export/data/numbers'
+      autoload :ParentLocales,             'cldr/export/data/parent_locales'
       autoload :Plurals,                   'cldr/export/data/plurals'
       autoload :PluralRules,               'cldr/export/data/plural_rules'
       autoload :Rbnf,                      'cldr/export/data/rbnf'

--- a/lib/cldr/export/data.rb
+++ b/lib/cldr/export/data.rb
@@ -10,6 +10,7 @@ module Cldr
       autoload :Currencies,                'cldr/export/data/currencies'
       autoload :CurrencyDigitsAndRounding, 'cldr/export/data/currency_digits_and_rounding'
       autoload :Delimiters,                'cldr/export/data/delimiters'
+      autoload :Fields,                    'cldr/export/data/fields'
       autoload :Languages,                 'cldr/export/data/languages'
       autoload :Layout,                    'cldr/export/data/layout'
       autoload :LikelySubtags,             'cldr/export/data/likely_subtags'

--- a/lib/cldr/export/data/fields.rb
+++ b/lib/cldr/export/data/fields.rb
@@ -1,0 +1,60 @@
+module Cldr
+  module Export
+    module Data
+      class Fields < Base
+        def initialize(locale)
+          super
+          update(:fields => fields)
+        end
+
+        private
+
+        def fields
+          select('dates/fields/field').each_with_object({}) do |field_node, ret|
+            type = field_node.attribute('type').value
+            ret[type] = field(field_node)
+          end
+        end
+
+        def field(field_node)
+          result = {}
+
+          unless (display_name = (field_node / 'displayName').text).empty?
+            result[:display_name] = display_name
+          end
+
+          unless (forms = relative_forms(field_node)).empty?
+            result[:relative] = forms
+          end
+
+          unless (forms = relative_time_forms(field_node)).empty?
+            result[:relative_time] = forms
+          end
+
+          result
+        end
+
+        def relative_forms(field_node)
+          (field_node / 'relative').each_with_object({}) do |relative_node, ret|
+            type = relative_node.attribute('type').value.to_i
+            ret[type] = relative_node.text
+          end
+        end
+
+        def relative_time_forms(field_node)
+          (field_node / 'relativeTime').each_with_object({}) do |relative_time_node, ret|
+            type = relative_time_node.attribute('type').value
+            ret[type] = relative_time_patterns(relative_time_node)
+          end
+        end
+
+        def relative_time_patterns(relative_time_node)
+          (relative_time_node / 'relativeTimePattern').each_with_object({}) do |relative_time_pattern_node, ret|
+            count = relative_time_pattern_node.attribute('count').value
+            ret[count] = relative_time_pattern_node.text
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cldr/export/data/parent_locales.rb
+++ b/lib/cldr/export/data/parent_locales.rb
@@ -1,0 +1,23 @@
+require 'nokogiri'
+
+module Cldr
+  module Export
+    module Data
+      class ParentLocales < Hash
+        def initialize
+          path = File.join(Cldr::Export::Data.dir, 'supplemental', 'supplementalData.xml')
+          doc = File.open(path) { |file| Nokogiri::XML(file) }
+
+          doc.xpath('//parentLocales/parentLocale').each do |node|
+            parent = node.attr('parent')
+            locales = node.attr('locales').split(' ')
+
+            locales.each do |locale|
+              self[locale] = parent
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cldr/thor.rb
+++ b/lib/cldr/thor.rb
@@ -5,7 +5,7 @@ module Cldr
   class Thor < ::Thor
     namespace 'cldr'
 
-    desc "download [--source=http://unicode.org/Public/cldr/24/core.zip] [--target=./vendor]",
+    desc "download [--source=http://unicode.org/Public/cldr/26/core.zip] [--target=./vendor]",
          "Download and extract CLDR data from source to target dir"
     method_options %w(source -s) => :string,
                    %w(target -t) => :string
@@ -27,7 +27,7 @@ module Cldr
       Cldr::Export.export(options.dup.symbolize_keys) { putc '.' }
       puts
     end
-  
+
     # TODO flatten task, e.g. flatten all plural locale files into one big file
   end
 end

--- a/test/export_test.rb
+++ b/test/export_test.rb
@@ -26,6 +26,11 @@ class TestExtract < Test::Unit::TestCase
     assert_equal 'NaN', data[:numbers][:symbols][:nan]
   end
 
+  test 'the merge option respects parentLocales' do
+    data = Cldr::Export.data('calendars', 'en-GB', :merge => true)
+    assert_equal 'dd/MM/y', data[:calendars][:gregorian][:additional_formats]['yMd']
+  end
+
   test "exports data to files" do
     Cldr::Export.export(:locales => %w(de), :components => %w(calendars))
     assert File.exists?(Cldr::Export.path('de', 'calendars', 'yml'))


### PR DESCRIPTION
Use the parentLocales section to figure out the correct fallback locales.  The new test passes when I unpack a modern CLDR in vendor/cldr.  I wasn't sure what the proper test procedure is but that worked so I went with it.  Let me know if I should change anything.